### PR TITLE
fix(is_template check): swap out call to viml string match function f…

### DIFF
--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -98,7 +98,7 @@ obsidian.setup = function(opts)
   if self.opts.templates ~= nil then
     local templates_pattern = "^" .. tostring(self.dir / self.opts.templates.subdir / ".*")
     is_template = function(match)
-      return vim.fn.matchstr(match, templates_pattern) ~= ""
+      return string.find(match, templates_pattern) ~= nil
     end
   else
     is_template = function(_)


### PR DESCRIPTION
…or builtin lua function.

This is useful for paths that contain tildes that need to be escaped. i.e. if the path to the vault is in an iCloud folder like: `/Users/person/Library/Mobile Documents/iCloud~md~obsidian/Documents/Notes`

using the viml string match currently throws an error if the user's vault path contains tildes.